### PR TITLE
Zwave

### DIFF
--- a/cluster/apps/home/README.md
+++ b/cluster/apps/home/README.md
@@ -1,0 +1,9 @@
+# Namespace: home
+
+This namespace is intended to be for home oriented things including home-automation
+
+Currently implementing:
+* [zwavejs2mqtt](https://artifacthub.io/packages/helm/k8s-at-home/zwavejs2mqtt) for managing zwave devices. Uses websockets for home-assistant, but mqtt for other apps such as node-red.
+* [ser2sock](https://artifacthub.io/packages/helm/k8s-at-home/ser2sock), for exposing zwave/zigbee adapters as tcp/ip resources. May move to [akri](https://github.com/project-akri/akri) in the future
+
+Note: Apps may be in use that aren't currently part of the cluster and this may seem confusing. Reach out with any questions via a 'Discussion' issue. I'm usually good about responding. If I don't, one of my robots will.

--- a/cluster/apps/home/ser2sock/helm-release.yaml
+++ b/cluster/apps/home/ser2sock/helm-release.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: ser2sock
+  namespace: default
+spec:
+  interval: 5m
+  chart:
+    spec:
+      # renovate: registryUrl=https://k8s-at-home.com/charts/
+      chart: ser2sock
+      version: 5.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: k8s-at-home-charts
+        namespace: flux-system
+      interval: 5m
+  values:
+    image:
+      repository: tenstartups/ser2sock
+      imagePullPolicy: IfNotPresent
+    env:
+      TZ: "${TZ}"
+      LISTENER_PORT: 10000
+      BAUD_RATE: 115200
+      SERIAL_DEVICE: "/dev/ttyUSB0"
+    securityContext:
+      privileged: true
+    tolerations:
+      - key: "arm"
+        operator: "Exists"
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - {key: "feature.node.kubernetes.io/custom-alarmdecoder", operator: In, values: ["true"]}
+    persistence:
+      usb:
+        enabled: true
+        type: hostPath
+        mountPath: /dev/ttyUSB0
+        hostPath: /dev/serial/by-id/usb-FTDI_FT230X_Basic_UART_DO00DPTS-if00-port0
+        # hostPathType: CharDevice
+    resources:
+      requests:
+        memory: 50Mi
+        cpu: 15m
+      limits:
+        memory: 250Mi

--- a/cluster/apps/home/ser2sock/kustomization.yaml
+++ b/cluster/apps/home/ser2sock/kustomization.yaml
@@ -2,6 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  # - home-assistant
-  - zwavejs2mqtt
-  - ser2sock
+  - helm-release.yaml

--- a/cluster/apps/home/zwavejs2mqtt/config-pvc.yaml
+++ b/cluster/apps/home/zwavejs2mqtt/config-pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: zwavejs2mqtt-config-v1
+  namespace: home
+  labels:
+    kasten.io/backup-volume: "enabled"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: ceph-block

--- a/cluster/apps/home/zwavejs2mqtt/helm-release.yaml
+++ b/cluster/apps/home/zwavejs2mqtt/helm-release.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: zwavejs2mqtt
+  namespace: home
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: zwavejs2mqtt
+      version: 5.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: k8s-at-home-charts
+        namespace: flux-system
+      interval: 5m
+  install:
+    createNamespace: true
+  values:
+    image:
+      repository: ghcr.io/zwave-js/zwavejs2mqtt
+      tag: 6.5.2
+    env:
+      TZ: "${TZ}"
+    service:
+      main:
+        ports:
+          http:
+            port: 8091
+          websocket:
+            enabled: true
+            port: 3000
+    ingress:
+      main:
+        enabled: true
+        ingressClassName: "traefik"
+        hajimari.io/appName: "zwaveJS"
+        hajimari.io/instance: "bloop-quarky"
+        hajimari.io/enable: "true"
+        hajimari.io/icon: "server"
+        cert-manager.io/cluster-issuer: letsencrypt-production
+        traefik.ingress.kubernetes.io/router.entrypoints: websecure
+        traefik.ingress.kubernetes.io/router.middlewares: networking-rfc1918@kubernetescrd
+        hosts:
+          - host: &host "zwave.${XYZ_DOMAIN}"
+            paths:
+              - path: /
+                pathType: Prefix
+        tls:
+          - hosts:
+              - *host
+    securityContext:
+      privileged: true
+    persistence:
+      config:
+        enabled: true
+        existingClaim: zwavejs2mqtt-config-v1
+        mountPath: "/usr/src/app/store"
+      usb:
+        enabled: true
+        type: hostPath
+        hostPath: /dev/serial/by-id/usb-0658_0200-if00
+        hostPathType: CharDevice
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: feature.node.kubernetes.io/custom-zwave
+                  operator: In
+                  values:
+                    - "true"

--- a/cluster/apps/home/zwavejs2mqtt/kustomization.yaml
+++ b/cluster/apps/home/zwavejs2mqtt/kustomization.yaml
@@ -2,5 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  # - home-assistant
-  - zwavejs2mqtt
+  - helm-release.yaml
+  - config-pvc.yaml


### PR DESCRIPTION
**Description of the change**

Adds HelmRelease for zwavejs2mqtt and ser2sock. Values will need to be updated once usb is inserted.

**Benefits**

Shifting current docker-compose 'orchestrated' containers to the cluster. Fulfil further non-devious amalgalmation plans, etc.

**Possible drawbacks**

ser2sock may not be the best possible choice, but it's not bad as far as I can tell

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
