### PR TITLE
Use domain for blocky "secure DNS"

### DIFF
--- a/cluster/apps/networking/blocky/helm-release.yaml
+++ b/cluster/apps/networking/blocky/helm-release.yaml
@@ -215,6 +215,7 @@ spec:
           emqx.${XYZ_DOMAIN}: ${LB_V4_TRAEFIK},${LB_V6_TRAEFIK}
           mqtt.${XYZ_DOMAIN}: ${LB_V4_TRAEFIK},${LB_V6_TRAEFIK}
           wss.${XYZ_DOMAIN}: ${LB_V4_TRAEFIK},${LB_V6_TRAEFIK}
+          dns.${XYZ_DOMAIN}: ${SVC_BLOCKY_ADDR_V4},${SVC_BLOCKY_ADDR_V6}
       blocking:
         blockType: zeroIp
         failStartOnListError: true


### PR DESCRIPTION
**Description of the change**

Adds a domain name for blocky LB

**Benefits**

Usable as "Private DNS" on Android when on LAN

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
