### PR TITLE
Add Object Stores to Ceph

### DIFF
--- a/cluster/core/rook-ceph/cluster/helm-release.yaml
+++ b/cluster/core/rook-ceph/cluster/helm-release.yaml
@@ -212,4 +212,35 @@ spec:
       #      csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
       #      csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
       #      csi.storage.k8s.io/fstype: ext4
-    cephObjectStores: []
+    #cephObjectStores: []
+    cephObjectStores:
+      - name: ceph-objectstore
+        spec:
+          metadataPool:
+            failureDomain: host
+            replicated:
+              size: 3
+          dataPool:
+            failureDomain: host
+            erasureCoded:
+              dataChunks: 2
+              codingChunks: 1
+          preservePoolsOnDelete: true
+          gateway:
+            port: 80
+            resources:
+              requests:
+                cpu: 1000m
+                memory: 1Gi
+              limits:
+                memory: 2Gi
+            instances: 1
+          healthCheck:
+            bucket:
+              interval: 60s
+        storageClass:
+          enabled: true
+          name: ceph-bucket
+          reclaimPolicy: Delete
+          parameters:
+            region: us-east-1


### PR DESCRIPTION
**Description of the change**

Adds cephObjectStores

**Benefits**

RGW gateway. S3 buckets like minio, but in the ceph storage

**Possible drawbacks**

ARM compatibility

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
