### PR TITLE
Add metallb v4 range to calico bgp

### DIFF
--- a/cluster/core/metallb-system/custom-resources/kustomization.yaml
+++ b/cluster/core/metallb-system/custom-resources/kustomization.yaml
@@ -3,6 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ip-address-pools.yaml
-  - layer2-advertisement.yaml
+  # - layer2-advertisement.yaml
   - bgp-peers.yaml
-  #- bgp-advertisement.yaml
+  # - bgp-advertisement.yaml

--- a/cluster/core/tigera-operator/bgp/bgp-config.yaml
+++ b/cluster/core/tigera-operator/bgp/bgp-config.yaml
@@ -13,3 +13,9 @@ spec:
     - cidr: "${NETWORK_BGP_BLOCK_V4}"
     - cidr: "${NETWORK_BGP_BLOCK_V6}"
     - cidr: "${LOCAL_CIDR_2}" # Refine to avoid collisions
+  serviceLoadBalancerIPs:
+    # metallb v4 range 10.1.0.100-10.1.0.255
+    - cidr: 10.1.0.100/30
+    - cidr: 10.1.0.104/29
+    - cidr: 10.1.0.112/28
+    - cidr: 10.1.0.128/25

--- a/cluster/core/tigera-operator/bgp/bgp-config.yaml
+++ b/cluster/core/tigera-operator/bgp/bgp-config.yaml
@@ -19,3 +19,4 @@ spec:
     - cidr: 10.1.0.104/29
     - cidr: 10.1.0.112/28
     - cidr: 10.1.0.128/25
+    - cidr: "${METALLB_LB_IP6_RANGE}"


### PR DESCRIPTION
**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

Already configured calico bgp. Will add notes for unifi config for readers.
Switched off kube-vip after editing kubernetes svc with ExternalIPs (used Cluster traffic policy)

This PR will retain metallb for provisioning/allocation and use calico for address advertisement 

**Benefits**

<!-- What benefits will be realized by the code change? -->

Will be able to shut down metallb-spealers after this since they won't be needed. Saving more and more resources. Efficiency, synergy and other buzzwords.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

If I break something it will break

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
